### PR TITLE
B/G deployに対応できていなかったので対応

### DIFF
--- a/ecs_practice/terraform/alb.tf
+++ b/ecs_practice/terraform/alb.tf
@@ -55,6 +55,12 @@ resource "aws_lb_listener" "internal" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.backend_blue.arn
   }
+
+  lifecycle {
+    ignore_changes = [
+      default_action, # B/G deployのため
+    ]
+  }
 }
 
 resource "aws_lb" "ingress" {

--- a/ecs_practice/terraform/ecs.tf
+++ b/ecs_practice/terraform/ecs.tf
@@ -37,6 +37,12 @@ resource "aws_ecs_service" "backend" {
       aws_security_group.this["backend"].id,
     ]
   }
+
+  lifecycle {
+    ignore_changes = [
+      load_balancer, # B/G deployのため
+    ]
+  }
 }
 
 resource "aws_ecs_task_definition" "backend" {
@@ -79,7 +85,7 @@ resource "aws_ecs_task_definition" "backend" {
 
   lifecycle {
     ignore_changes = [
-      container_definitions, # CI/CDなどTerraform外でタスク定義を更新するためtame
+      container_definitions, # CI/CDなどTerraform外でタスク定義を更新するため
     ]
   }
 }
@@ -128,7 +134,7 @@ resource "aws_ecs_task_definition" "frontend" {
 
   lifecycle {
     ignore_changes = [
-      container_definitions, # CI/CDなどTerraform外でタスク定義を更新するためtame
+      container_definitions, # CI/CDなどTerraform外でタスク定義を更新するため
     ]
   }
 }


### PR DESCRIPTION
B/G deploy後、target groupなどの設定が切り替わるがTerraformでは切り替わる前のtarget groupを管理しているためdriftが出てしまう。
そのためignoreした